### PR TITLE
Add fractional year mortality and death distribution assumptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,54 @@ MortalityTable:
        2001 Valuation Basic Table (VBT) Residual Standard Select and Ultimate Table -  Male Nonsmoker. Basis: Age Nearest Birthday. Minimum Select Age: 0. Maximum Select Age: 99. Minimum Ultimate Age: 25. Maximum Ultimate Age: 120
 ```
 
+#### Fractional Years
+When evaluating survival over partial years when you are given full year mortality
+rates, you must make an assumption over how those deaths are distributed throughout
+the year. Three assumptions are provided as options and are based on formulas
+from the [2016 Experience Study Calculations paper from the SOA](https://www.soa.org/globalassets/assets/Files/Research/2016-10-experience-study-calculations.pdf), specifically pages 40-44.
+
+The three assumptions are:
+
+- `Uniform()` which assumes an increasing force of mortality throughout the year.
+- `Constant()` which assumes a level force of mortality throughout the year.
+- `Balducci()` which assumes a decreasing force of mortality over the year. It seems [to
+be for](https://www.soa.org/globalassets/assets/library/research/actuarial-research-clearing-house/1978-89/1988/arch-1/arch88v17.pdf) making it easier to calculate successive months by hand.
+
+##### Usage
+
+When you call a method below that uses the `time` argument (ie a period over which
+    you want to calculate the force of mortality), if you use a non `Int` (integer)
+    number then you need to specify the assumption as the last argument.
+
+For example:
+
+Don't need to specify because you gave an `Int` time:
+
+```julia
+# calculate the 5-year survival for a person issued at age 50 and in
+# the first duration
+issue_age = 50
+duration = 1
+time = 5
+p(table,issue_age,duration,time)
+```
+Don't need to specify because you gave an fractional floating time:
+
+```julia
+# calculate the 5-and-a-half-year survival for a
+# person issued at age 50 and in the first duration
+issue_age = 50
+duration = 1
+time = 5.5
+p(table,issue_age,duration,time, Balducci())
+```
+
+Note that if you are passing floating point numbers as the `time`
+argument, you still have to specify a mortality assumption because
+[floating point numbers](https://en.wikipedia.org/wiki/Floating-point_arithmetic) are often *technically* not whole numbers even
+if you define a number to be, say, `5.0`.
+
+
 ### Actuarial Notation Equivalants
 #### `ₜp₍ₓ₎₊ₛ`
 The probability that a life aged `x + s` who was select

--- a/src/MortalityTable.jl
+++ b/src/MortalityTable.jl
@@ -140,8 +140,14 @@ Equivalant actuarial notation:
 ``$_tp_{(x)+s}$``, or the probability that a life aged `x + s` who was select
 at age `x` survives to at least age `x+s+t`
 """
-function p(table::MortalityDict,issue_age,duration,time)
+function p(table::MortalityDict,issue_age,duration,time::Int)
     prod(1.0 .- q(table,issue_age,duration:(duration+time-1)))
+end
+function p(table::MortalityDict,issue_age,duration,time)
+    error("If you use non-integer times, you need to specify a \n
+    distribution of deaths assumption (e.g. `Balducci()`, \n
+    `Constant()`, or `Uniform()` as the last argument to your \n
+    function call.")
 end
 
 @doc raw"""
@@ -155,8 +161,15 @@ function p(table::MortalityDict,issue_age,duration)
     return 1.0 - q(table,issue_age,duration)
 end
 
-function p(table::UltimateMortalityTable,issue_age,duration)
+function p(table::UltimateMortalityTable,issue_age,duration::Int)
     return p(table.ultimate,issue_age,duration)
+end
+
+function p(table::UltimateMortalityTable,issue_age,duration)
+    error("If you use non-integer times, you need to specify a \n
+    distribution of deaths assumption (e.g. `Balducci()`, \n
+    `Constant()`, or `Uniform()` as the last argument to your \n
+    function call.")
 end
 
 @doc raw"""

--- a/src/MortalityTable.jl
+++ b/src/MortalityTable.jl
@@ -144,10 +144,12 @@ function p(table::MortalityDict,issue_age,duration,time::Int)
     prod(1.0 .- q(table,issue_age,duration:(duration+time-1)))
 end
 function p(table::MortalityDict,issue_age,duration,time)
-    error("If you use non-integer times, you need to specify a \n
-    distribution of deaths assumption (e.g. `Balducci()`, \n
-    `Constant()`, or `Uniform()` as the last argument to your \n
-    function call.")
+    throw(
+        ArgumentError("time: $time - If you use non-integer time, you need to specify a \n
+        distribution of deaths assumption (e.g. `Balducci()`, \n
+        `Constant()`, or `Uniform()` as the last argument to your \n
+        function call.")
+    )
 end
 
 @doc raw"""
@@ -166,10 +168,12 @@ function p(table::UltimateMortalityTable,issue_age,duration::Int)
 end
 
 function p(table::UltimateMortalityTable,issue_age,duration)
-    error("If you use non-integer times, you need to specify a \n
-    distribution of deaths assumption (e.g. `Balducci()`, \n
-    `Constant()`, or `Uniform()` as the last argument to your \n
-    function call.")
+    throw(
+        ArgumentError("time: $time - If you use non-integer time, you need to specify a \n
+        distribution of deaths assumption (e.g. `Balducci()`, \n
+        `Constant()`, or `Uniform()` as the last argument to your \n
+        function call.")
+    )
 end
 
 @doc raw"""
@@ -181,12 +185,30 @@ Equivalent actuarial notation:
 ``$p_{(x)+s}$``  or the probability that a life aged `x + s` who was select
 at age `x` dies by least age `x+s+t`
 """
-function q(table::MortalityDict,issue_age,duration,time)
+function q(table::MortalityDict,issue_age,duration,time::Int)
     1.0 - p(table::MortalityDict,issue_age,duration,time)
+end
+function q(table::MortalityDict,issue_age,duration,time)
+    throw(
+        ArgumentError("time: $time - If you use non-integer time, you need to specify a \n
+        distribution of deaths assumption (e.g. `Balducci()`, \n
+        `Constant()`, or `Uniform()` as the last argument to your \n
+        function call.")
+    )
+
+end
+
+function q(table::UltimateMortalityTable,issue_age,duration,time::Int)
+    return q(table.ultimate,issue_age,duration,time)
 end
 
 function q(table::UltimateMortalityTable,issue_age,duration,time)
-    return q(table.ultimate,issue_age,duration,time)
+    throw(
+        ArgumentError("time: $time - If you use non-integer time, you need to specify a \n
+        distribution of deaths assumption (e.g. `Balducci()`, \n
+        `Constant()`, or `Uniform()` as the last argument to your \n
+        function call.")
+    )
 end
 
 

--- a/src/MortalityTables.jl
+++ b/src/MortalityTables.jl
@@ -1,6 +1,7 @@
 module MortalityTables
 
 include("Mortality.jl")
+include("death_distribution.jl")
 
 
 export MortalityTable,
@@ -10,5 +11,6 @@ export MortalityTable,
     SelectMortality,
     UltimateMortality,
     MortalityVector,
-    MortalityTable
+    MortalityTable,
+    Balducci, Uniform, Constant, DeathDistribution
 end # module

--- a/src/death_distribution.jl
+++ b/src/death_distribution.jl
@@ -1,0 +1,118 @@
+"""
+    DeathDistribution
+
+An abstract type used to form an assumption of how deaths occur throughout a
+    year. See `Balducci()`, `Uniform()`, and `Constant()` for concrete
+    assumption types.
+"""
+abstract type DeathDistribution end
+
+"""
+    Balducci()
+
+A `DeathDistribution` type that assumes a decreasing force of mortality
+over the year.
+"""
+struct Balducci <: DeathDistribution end
+
+"""
+    Uniform()
+
+A `DeathDistribution` type that assumes an increasing force of mortality
+over the year.
+"""
+struct Uniform  <: DeathDistribution end
+
+"""
+    Constant()
+
+A `DeathDistribution` type that assumes a constant force of mortality
+over the year.
+"""
+struct Constant  <: DeathDistribution end
+
+# Reference: Experience Study Calculations, 2016, Society of Actuaries
+# https://www.soa.org/globalassets/assets/Files/Research/2016-10-experience-study-calculations.pdf
+
+"""
+    q(MortalityTable,issue_age,duration,time,DeathDistribution)
+
+A function to calculate non-whole year force of mortality, where you must
+    make an assumption (`DeathDistribution`) about how the annual rate of
+    mortaility applies through the rest of the year.
+"""
+function q(tbl,issue_age,duration,time,dist)
+    return 1 - p(tbl,issue_age,duration,time,dist)
+end
+
+"""
+    p(MortalityTable,issue_age,duration,time,DeathDistribution)
+
+A function to calculate non-whole year survivorship, where you must
+    make an assumption (`DeathDistribution`) about how the annual rate of
+    mortaility applies through the rest of the year.
+"""
+function p(tbl,issue_age,duration,time,dist::Balducci)
+
+    if  time > 1
+        whole_time = trunc(Int,time)
+        p′ = p(tbl,issue_age,duration,whole_time)
+        return   p′ * p(tbl,issue_age,duration + whole_time,time-whole_time,dist)
+    else
+        # when the original time is a whole number, the remainder of time
+        # can be zero, but the duration was incremented past the end of the table
+        # as a result
+        duration = time == 0 ? duration - 1 : duration
+        q′ = q(tbl,issue_age,duration)
+
+        return (1 - q′) / ( 1 - (1 - time) * q′)
+    end
+end
+
+"""
+    p(MortalityTable,issue_age,duration,time,DeathDistribution)
+
+A function to calculate non-whole year survivorship, where you must
+    make an assumption (`DeathDistribution`) about how the annual rate of
+    mortaility applies through the rest of the year.
+"""
+function p(tbl,issue_age,duration,time,dist::Constant)
+
+    if  time > 1
+        whole_time = trunc(Int, time)
+        p′ = p(tbl,issue_age,duration,whole_time)
+        return   p′ * p(tbl,issue_age,duration + whole_time,time-whole_time,dist)
+    else
+        # when the original time is a whole number, the remainder of time
+        # can be zero, but the duration was incremented past the end of the table
+        # as a result
+        duration = time == 0 ? duration - 1 : duration
+        q′ = q(tbl,issue_age,duration)
+
+        return (1 - q′) ^ time
+    end
+end
+
+"""
+    p(MortalityTable,issue_age,duration,time,DeathDistribution)
+
+A function to calculate non-whole year survivorship, where you must
+    make an assumption (`DeathDistribution`) about how the annual rate of
+    mortaility applies through the rest of the year.
+"""
+function p(tbl,issue_age,duration,time,dist::Uniform)
+
+    if  time > 1
+        whole_time = trunc(Int,time)
+        p′ = p(tbl,issue_age,duration,whole_time)
+        return   p′ * p(tbl,issue_age,duration + whole_time,time-whole_time,dist)
+    else
+        # when the original time is a whole number, the remainder of time
+        # can be zero, but the duration was incremented past the end of the table
+        # as a result
+        duration = time == 0 ? duration - 1 : duration
+        q′ = q(tbl,issue_age,duration)
+
+        return (1 - time * q′)
+    end
+end

--- a/test/distribution.jl
+++ b/test/distribution.jl
@@ -39,4 +39,10 @@
             end
         end
     end
+
+    @testset "Error when asking for a fractional without assumption" begin
+        mort = UltimateMortality([.20,.50])
+        @test_throws ArgumentError q(mort,0,1,1.5)
+        @test_throws ArgumentError p(mort,0,1,1.5)
+    end
 end

--- a/test/distribution.jl
+++ b/test/distribution.jl
@@ -1,0 +1,42 @@
+# Reference: Experience Study Calculations, 2016, Society of Actuaries
+# https://www.soa.org/globalassets/assets/Files/Research/2016-10-experience-study-calculations.pdf
+# examples on pages 41-45
+@testset "Fractional Year and distribution of deaths" begin
+    @testset "SOA Experience Study Calcuations distribution examples" begin
+        soa_mort = UltimateMortality([.12])
+
+        methods = [Balducci(), Uniform(), Constant()]
+        time_targets = Dict(
+            1/12  => [0.9888, 0.9900, 0.9894],
+            6/12  => [0.9362, 0.9400, 0.9381],
+            7/12  => [0.9263, 0.9300, 0.9281],
+            12/12 => [0.8800, 0.8800, 0.8800]
+
+        )
+        for i in 1:length(methods)
+            for (t,target) in time_targets
+                @test round(p(soa_mort,0,1,t,methods[i]),digits=4) == target[i]
+                @test round(q(soa_mort,0,1,t,methods[i]),digits=4) == round(1 - target[i], digits=4)
+            end
+        end
+    end
+    @testset "Multi-year examples" begin
+        mort = UltimateMortality([.20,.50])
+        methods = [Balducci(), Uniform(), Constant()]
+
+        # these sample values calculated manually
+        time_targets = Dict(
+            1 + 1/12  => [0.7385, 0.7667, 0.7551],
+            1 + 6/12  => [0.5333, 0.6000, 0.5657],
+            1 + 7/12  => [0.5053, 0.5667, 0.5339],
+            1 + 12/12 => [0.4000, 0.4000, 0.4000]
+
+        )
+        for i in 1:length(methods)
+            for (t,target) in time_targets
+                @test round(p(mort,0,1,t,methods[i]),digits=4) == target[i]
+                @test round(q(mort,0,1,t,methods[i]),digits=4) == round(1 - target[i], digits=4)
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test
 
 include("basic.jl")
 include("XTbML.jl")
+include("distribution.jl")
 
 #load tables to be used in subsequent tests
 tables = MortalityTables.tables()


### PR DESCRIPTION
When evaluating survival over partial years when you are given full year mortality
rates, you must make an assumption over how those deaths are distributed throughout
the year. Three assumptions are provided as options and are based on formulas
from the [2016 Experience Study Calculations paper from the SOA](https://www.soa.org/globalassets/assets/Files/Research/2016-10-experience-study-calculations.pdf), specifically pages 40-44.

The three assumptions are:

- `Uniform()` which assumes an increasing force of mortality throughout the year.
- `Constant()` which assumes a level force of mortality throughout the year.
- `Balducci()` which assumes a decreasing force of mortality over the year. It seems [to
be for](https://www.soa.org/globalassets/assets/library/research/actuarial-research-clearing-house/1978-89/1988/arch-1/arch88v17.pdf) making it easier to calculate successive months by hand.