### PR TITLE
Use parallelism to reduce load time of tables

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -153,12 +153,6 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
-[[ProgressMeter]]
-deps = ["Distributed", "Printf"]
-git-tree-sha1 = "ea1f4fa0ff5e8b771bf130d87af5b7ef400760bd"
-uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
-version = "1.2.0"
-
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,7 +1,34 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[ArgCheck]]
+git-tree-sha1 = "59c256cf71c3982484ae4486ee86a3d7da891dea"
+uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+version = "2.0.0"
+
+[[BangBang]]
+deps = ["Compat", "ConstructionBase", "Future", "InitialValues", "LinearAlgebra", "Requires", "Setfield", "Tables", "ZygoteRules"]
+git-tree-sha1 = "c9ad7258a3fe28cec503cda05dcd59afc9d2b4c3"
+uuid = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
+version = "0.3.19"
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "fecfed095803b86cc06fd7ee09d3d2c98fad4dac"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.9.0"
+
+[[ConstructionBase]]
+git-tree-sha1 = "a2a6a5fea4d6f730ec4c18a76d27ec10e8ec1c50"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.0.0"
+
+[[DataAPI]]
+git-tree-sha1 = "176e23402d80e7743fc26c19c681bfb11246af32"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.3.0"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
@@ -9,9 +36,18 @@ git-tree-sha1 = "5a431d46abf2ef2a4d5d00bd0ae61f651cf854c8"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 version = "0.17.10"
 
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
@@ -22,6 +58,10 @@ deps = ["Printf", "XML2_jll"]
 git-tree-sha1 = "0fa3b52a04a4e210aeb1626def9c90df3ae65268"
 uuid = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 version = "1.1.0"
+
+[[Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
 [[HTTP]]
 deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
@@ -35,6 +75,11 @@ git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
 uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
 version = "0.5.0"
 
+[[InitialValues]]
+git-tree-sha1 = "ef18588a15dcd6aff37a09108d7b3754093d73be"
+uuid = "22cec73e-a1b8-11e9-2c92-598750a2cf9c"
+version = "0.2.2"
+
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -43,6 +88,11 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 git-tree-sha1 = "05110a2ab1fc5f932622ffea2a003221f4782c18"
 uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 version = "1.3.0"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
 
 [[LibGit2]]
 deps = ["Printf"]
@@ -57,8 +107,18 @@ git-tree-sha1 = "e5256a3b0ebc710dbd6da0c0b212164a3681037f"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
 version = "1.16.0+2"
 
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "f7d2e3f654af75f01ec49be82c231c382214223a"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.5"
 
 [[Markdown]]
 deps = ["Base64"]
@@ -75,6 +135,9 @@ deps = ["Libdl", "Pkg"]
 git-tree-sha1 = "c83f5a1d038f034ad0549f9ee4d5fac3fb429e33"
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 version = "2.16.0+2"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[OrderedCollections]]
 deps = ["Random", "Serialization", "Test"]
@@ -104,18 +167,66 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[[Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "d37400976e98018ee840e0ca4f9d20baa231dc6b"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.0.1"
+
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
+[[Setfield]]
+deps = ["ConstructionBase", "Future", "MacroTools", "Requires"]
+git-tree-sha1 = "7a151f918819326a6003dba451dabe65f8c0f6fb"
+uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
+version = "0.6.0"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[SplittablesBase]]
+deps = ["Setfield", "Test"]
+git-tree-sha1 = "824da53be38fd36c33c25ffc092fd5aacfe7a1e2"
+uuid = "171d559e-b47b-412a-8079-5efa626c420e"
+version = "0.1.1"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "b1ad568ba658d8cbb3b892ed5380a6f3e781a81e"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.0"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "c45dcc27331febabc20d86cb3974ef095257dcf3"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.0.4"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[Transducers]]
+deps = ["ArgCheck", "BangBang", "Distributed", "InitialValues", "Logging", "Markdown", "Requires", "Setfield", "SplittablesBase", "Tables"]
+git-tree-sha1 = "cdbefb90997962d9c93f75b970a129a87d5ffab4"
+uuid = "28d57a85-8fef-5791-bfe6-a80928e7c999"
+version = "0.4.26"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -141,3 +252,9 @@ deps = ["Libdl", "Pkg"]
 git-tree-sha1 = "2f6c3e15e20e036ee0a0965879b31442b7ec50fa"
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 version = "1.2.11+9"
+
+[[ZygoteRules]]
+deps = ["MacroTools"]
+git-tree-sha1 = "b3b4882cc9accf6731a08cc39543fbc6b669dca8"
+uuid = "700de1a5-db45-46bc-99cf-38207098b444"
+version = "0.2.0"

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.8.0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -6,14 +6,12 @@ version = "0.8.0"
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
 DataStructures = "^0.16, 0.17"
 HTTP = "^0.8"
-ProgressMeter = "^1.2"
 XMLDict = "0.4"
 julia = "^1.3"
 

--- a/src/MortalityTable.jl
+++ b/src/MortalityTable.jl
@@ -1,5 +1,5 @@
 using DataStructures
-
+using Transducers
 
 include("MetaData.jl")
 
@@ -154,8 +154,9 @@ Equivalant actuarial notation:
 at age `x` survives to at least age `x+s+t`
 """
 function p(table::MortalityDict, issue_age, duration, time::Int)
-    prod(1.0 .- q(table, issue_age, duration:(duration+time-1)))
+    reduce(*,1.0 .- q(table, issue_age, duration:(duration+time-1)))
 end
+
 function p(table::MortalityDict, issue_age, duration, time)
     throw(ArgumentError("time: $time - If you use non-integer time, you need to specify a \n
           distribution of deaths assumption (e.g. `Balducci()`, \n

--- a/src/XTbML.jl
+++ b/src/XTbML.jl
@@ -179,15 +179,12 @@ function tables(dir = nothing)
     else
         table_dir = dir
     end
-
-    tables = Dict()
+    tables = []
+    @info "Loading built-in Mortality Tables..."
     for (root, dirs, files) in walkdir(table_dir)
-        @showprogress "loading table files..." for file in files
-            if basename(file)[end-3:end] == ".xml"
-                tbl = readXTbML(joinpath(root, file))
-                tables[tbl.d.name] = tbl
-            end
-        end
+        transducer = Filter(x -> basename(x)[end-3:end] == ".xml") |> Map(x ->  readXTbML(joinpath(root, x)) )
+        tables = tcopy(transducer,files  )
     end
-    return tables
+    # return tables
+    return Dict(tbl.d.name => tbl for tbl in tables if ~isnothing(tbl))
 end

--- a/src/XTbML.jl
+++ b/src/XTbML.jl
@@ -1,6 +1,5 @@
 import DataStructures
 import XMLDict
-using ProgressMeter
 
 include("MortalityTable.jl")
 


### PR DESCRIPTION
Before:
```julia-repl
julia> @benchmark  MortalityTables.tables()
BenchmarkTools.Trial:
  memory estimate:  2.44 GiB
  allocs estimate:  62552850
  --------------
  minimum time:     6.895 s (5.75% GC)
  median time:      6.895 s (5.75% GC)
  mean time:        6.895 s (5.75% GC)
  maximum time:     6.895 s (5.75% GC)
  --------------
  samples:          1
  evals/sample:     1
```

After:
```julia-repl
julia> @benchmark  MortalityTables.tables()
BenchmarkTools.Trial:
  memory estimate:  2.43 GiB
  allocs estimate:  62165872
  --------------
  minimum time:     2.709 s (24.99% GC)
  median time:      2.934 s (25.50% GC)
  mean time:        2.934 s (25.50% GC)
  maximum time:     3.160 s (25.94% GC)
  --------------
  samples:          2
  evals/sample:     1
```