### PR TITLE
Rename survivorship -> survival

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 A Julia package for working with MortalityTables. Has:
 
 - Lots of bundled SOA mort.soa.org tables
-- `survivorship` and `decrement` functions to calculate decrements over period of time
+- `survival` and `decrement` functions to calculate decrements over period of time
 - Partial year mortality calculations (Uniform, Constant, Balducci)
 - Friendly syntax and flexible usage
 - Extensive set of parametric mortality models.
@@ -72,10 +72,10 @@ julia> vbt2001.ultimate[95]  # ultimate vectors only need to be called with the 
  0.24298
 ```
 
-Calculate the force of mortality or survivorship over a range of time:
+Calculate the force of mortality or survival over a range of time:
 
 ```julia
-julia> survivorship(vbt2001.ultimate,30,40) # the survivorship between ages 30 and 40
+julia> survival(vbt2001.ultimate,30,40) # the survival between ages 30 and 40
 0.9894404665434904
 
 julia> decrement(vbt2001.ultimate,30,40) # the decrement between ages 30 and 40
@@ -85,7 +85,7 @@ julia> decrement(vbt2001.ultimate,30,40) # the decrement between ages 30 and 40
 Non-whole periods of time are supported when you specify the assumption (`Constant()`, `Uniform()`, or `Balducci()`) for fractional periods:
 
 ```julia
-julia> survivorship(vbt2001.ultimate,30,40.5,Uniform()) # the survivorship between ages 30 and 40.5
+julia> survival(vbt2001.ultimate,30,40.5,Uniform()) # the survival between ages 30 and 40.5
 0.9887676470262408
 ```
 
@@ -235,7 +235,7 @@ Now some examples with `m`, but could use `g` interchangeably:
 age = 20
 m[20]                 # the mortality rate at age 20
 decrement(m,20,25)    # the five year cumulative mortality rate
-survivorship(m,20,25) # the five year survivorship rate
+survival(m,20,25) # the five year survival rate
 ```
 
 Because of the large number of parameters and the likelihood for confusion, these models:

--- a/src/MortalityTable.jl
+++ b/src/MortalityTable.jl
@@ -139,13 +139,13 @@ Base.show(io::IO, ::MIME"text/plain", mt::MortalityTable) = print(
 
 
 """
-    survivorship(mortality_vector,to_age)
-    survivorship(mortality_vector,from_age,to_age)
+    survival(mortality_vector,to_age)
+    survival(mortality_vector,from_age,to_age)
 
-Returns the survivorship through attained age `to_age`. The start of the calculation is either the start of the vector, or attained_age `from_age`. `from_age` and `to_age` need to be Integers. Add a DeathDistribution as the last argument to handle floating point and non-whole ages:
+Returns the survival through attained age `to_age`. The start of the calculation is either the start of the vector, or attained_age `from_age`. `from_age` and `to_age` need to be Integers. Add a DeathDistribution as the last argument to handle floating point and non-whole ages:
 
-    survivorship(mortality_vector,to_age,::DeathDistribution)
-    survivorship(mortality_vector,from_age,to_age,::DeathDistribution)
+    survival(mortality_vector,to_age,::DeathDistribution)
+    survival(mortality_vector,from_age,to_age,::DeathDistribution)
 
 If given a negative `to_age`, it will return `1.0`. Aside from simplifying the code, this makes sense as for something to exist in order to decrement in the first place, it must have existed and surived to the point of  being able to be decremented.
 
@@ -153,28 +153,28 @@ If given a negative `to_age`, it will return `1.0`. Aside from simplifying the c
 ```julia-repl
 julia> qs = UltimateMortality([0.1,0.3,0.6,1]);
     
-julia> survivorship(qs,0)
+julia> survival(qs,0)
 1.0
-julia> survivorship(qs,1)
+julia> survival(qs,1)
 0.9
 
-julia> survivorship(qs,1,1)
+julia> survival(qs,1,1)
 1.0
-julia> survivorship(qs,1,2)
+julia> survival(qs,1,2)
 0.7
 
-julia> survivorship(qs,0.5,Uniform())
+julia> survival(qs,0.5,Uniform())
 0.95
 ```
 """
-function survivorship(v, to_age)
-    return survivorship(v, firstindex(v), to_age)
+function survival(v, to_age)
+    return survival(v, firstindex(v), to_age)
 end
-function survivorship(v, to_age, dd::DeathDistribution)
-    return survivorship(v, firstindex(v), to_age, dd)
+function survival(v, to_age, dd::DeathDistribution)
+    return survival(v, firstindex(v), to_age, dd)
 end
 
-function survivorship(v::T, from_age::Int, to_age::Int) where {T <: AbstractArray}
+function survival(v::T, from_age::Int, to_age::Int) where {T <: AbstractArray}
     if from_age == to_age
         return 1.0
     else
@@ -185,13 +185,13 @@ function survivorship(v::T, from_age::Int, to_age::Int) where {T <: AbstractArra
     end
 end
 
-function survivorship(v::T, from_age, to_age, dd::DeathDistribution) where {T <: AbstractArray}
-    # calculate the survivorship for the rounded ages, and then the high and low high_residual
+function survival(v::T, from_age, to_age, dd::DeathDistribution) where {T <: AbstractArray}
+    # calculate the survival for the rounded ages, and then the high and low high_residual
     age_low = ceil(Int, from_age)
     age_high = floor(Int, to_age)
 
     #if from_age and to_age are fractional parts of the same attained age, then age_high will round down to 
-    # be below the rounded-up age_low. This line will short circuit the rest and just return the fractional year survivorship
+    # be below the rounded-up age_low. This line will short circuit the rest and just return the fractional year survival
     age_high < age_low && return 1 - decrement_partial_year(v, from_age, to_age, dd)
     
     
@@ -263,10 +263,10 @@ julia> decrement(qs,0.5,Uniform())
 0.05
 ```
 """
-decrement(v,to_age) = 1 .- survivorship(v, to_age)
-decrement(v,to_age,dd::DeathDistribution) = 1 .- survivorship(v, to_age, dd)  
-decrement(v,from_age,to_age) = 1 .- survivorship(v, from_age, to_age) 
-decrement(v,from_age,to_age,dd::DeathDistribution) = 1 .- survivorship(v, from_age, to_age, dd) 
+decrement(v,to_age) = 1 .- survival(v, to_age)
+decrement(v,to_age,dd::DeathDistribution) = 1 .- survival(v, to_age, dd)  
+decrement(v,from_age,to_age) = 1 .- survival(v, from_age, to_age) 
+decrement(v,from_age,to_age,dd::DeathDistribution) = 1 .- survival(v, from_age, to_age, dd) 
 
 
 """

--- a/src/MortalityTables.jl
+++ b/src/MortalityTables.jl
@@ -14,7 +14,7 @@ include("get_SOA_table.jl")
 include("parameterized_models.jl")
 
 export MortalityTable,
-    survivorship,
+    survival,
     decrement,
     omega,
     TableMetaData,

--- a/src/parameterized_models.jl
+++ b/src/parameterized_models.jl
@@ -32,7 +32,7 @@ function cumhazard(m::Makeham,age)
     return a / b * (exp(b*age) - 1) + age * c
 end
 
-survivorship(m::Makeham,age) = exp(-cumhazard(m,age))
+survival(m::Makeham,age) = exp(-cumhazard(m,age))
 
 
 """
@@ -74,9 +74,9 @@ function hazard(m::InverseGompertz,age)
     return 1 / σ * exp(-(age - m)/σ) / (exp(exp(-(age - m)/σ)) - 1)
 end
 
-cumhazard(m::InverseGompertz,age) = -log(survivorship(m,age))
+cumhazard(m::InverseGompertz,age) = -log(survival(m,age))
 
-function survivorship(m::InverseGompertz,age) 
+function survival(m::InverseGompertz,age) 
     @unpack m,σ = m 
     return (1 - exp(-exp(-(age - m)/σ))) / (1 - exp(-exp(m/σ)))
 end
@@ -200,7 +200,7 @@ function cumhazard(m::Weibull,age)
     return (age / m) ^ (m / σ)
 end
 
-function survivorship(m::Weibull,age) 
+function survival(m::Weibull,age) 
     return exp(-cumhazard(m,age))
 end
 
@@ -234,7 +234,7 @@ function cumhazard(m::InverseWeibull,age)
     return -log(1 - exp(-(age/m)^(-m/σ)))
 end
 
-function survivorship(m::InverseWeibull,age) 
+function survival(m::InverseWeibull,age) 
     return exp(-cumhazard(m,age))
 end
 
@@ -727,7 +727,7 @@ function cumhazard(m::Kannisto,age)
     return  1/a * log((1 + b*exp(b*age)) / (1 + a))
 end
 
-function  survivorship(m::Kannisto,age)
+function  survival(m::Kannisto,age)
     return exp(-cumhazard(m,age))
 end
 
@@ -767,19 +767,19 @@ end
 
 
 # # use the integral to calculate the one-year survival
-# function survivorship(m::ParametricMortality, from_age, to_age) 
+# function survival(m::ParametricMortality, from_age, to_age) 
 #     if from_age == to_age
 #         return 1.0
 #     else
 #         return exp(-quadgk(age->μ(m, age), from_age, to_age)[1])
 #     end
 # end
-# survivorship(m::ParametricMortality,to_age) = survivorship(m, 0, to_age)
+# survival(m::ParametricMortality,to_age) = survival(m, 0, to_age)
 
-survivorship(m::ParametricMortality,to_age) = exp(-quadgk(age->μ(m, age), 0, to_age)[1])
-survivorship(m,from,to) = survivorship(m,to) / survivorship(m,from)
-decrement(m::ParametricMortality,from_age,to_age) = 1 - survivorship(m, from_age, to_age)
-decrement(m::ParametricMortality,to_age) = 1 - survivorship(m, to_age)
+survival(m::ParametricMortality,to_age) = exp(-quadgk(age->μ(m, age), 0, to_age)[1])
+survival(m,from,to) = survival(m,to) / survival(m,from)
+decrement(m::ParametricMortality,from_age,to_age) = 1 - survival(m, from_age, to_age)
+decrement(m::ParametricMortality,to_age) = 1 - survival(m, to_age)
 
 (m::ParametricMortality)(x) = μ(m, x)
 Base.getindex(m::ParametricMortality,x) = m(x)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -55,23 +55,23 @@
     @testset "accumulated force" begin
         q4 = UltimateMortality([0.1,0.3,0.6,1])
         
-        @test survivorship(q4, 0) ≈ 1
+        @test survival(q4, 0) ≈ 1
         @test decrement(q4, 0) ≈ 0
 
-        @test survivorship(q4, 1) ≈ 0.9
+        @test survival(q4, 1) ≈ 0.9
         @test decrement(q4, 1) ≈ 0.1
 
-        @test survivorship(q4, 1, 1) ≈ 1.0
-        @test survivorship(q4, 1, 2) ≈ 0.7
+        @test survival(q4, 1, 1) ≈ 1.0
+        @test survival(q4, 1, 2) ≈ 0.7
         @test decrement(q4, 1, 1) ≈ 0.0
         @test decrement(q4, 1, 2) ≈ 0.3
         
-        @test survivorship(q4, 1, 4) ≈ 0.0
+        @test survival(q4, 1, 4) ≈ 0.0
         @test decrement(q4, 1, 4) ≈ 1.0
 
         
-        @test survivorship(q4, -1) ≈ 1.0
-        @test survivorship(q4, 4, -1) ≈ 1.0
+        @test survival(q4, -1) ≈ 1.0
+        @test survival(q4, 4, -1) ≈ 1.0
         @test decrement(q4, -1) ≈ 0.0
         @test decrement(q4, 4, -1) ≈ 0.0
     end

--- a/test/distribution.jl
+++ b/test/distribution.jl
@@ -15,8 +15,8 @@
 
         # test whole ages with assumption argument
         for method in methods
-            @test survivorship(soa_mort, 0, 1, method) == 0.88
-            @test survivorship(soa_mort, 1, method) == 0.88
+            @test survival(soa_mort, 0, 1, method) == 0.88
+            @test survival(soa_mort, 1, method) == 0.88
             @test decrement(soa_mort, 0, 1, method) == 0.12
             @test decrement(soa_mort, 1, method) == 0.12
 
@@ -28,7 +28,7 @@
         # test fractional ages
         for i = 1:length(methods)
             for (t, target) in time_targets
-                @test round(survivorship(soa_mort, t, methods[i]), digits = 4) ==
+                @test round(survival(soa_mort, t, methods[i]), digits = 4) ==
                       target[i]
 
                 @test round(MortalityTables.decrement_partial_year(soa_mort, 0, t, methods[i]),
@@ -42,7 +42,7 @@
         # test time zero when given distribution of deaths
         for m in methods
             @test decrement(soa_mort, 0, m) == 0.0
-            @test survivorship(soa_mort, 0, m) == 1.0
+            @test survival(soa_mort, 0, m) == 1.0
         end
     end
     @testset "Multi-year examples" begin
@@ -67,7 +67,7 @@
         # test fractional ages
         for i = 1:length(methods)
             for (t, target) in time_targets
-                @test round(survivorship(mort, t, methods[i]), digits = 4) ==
+                @test round(survival(mort, t, methods[i]), digits = 4) ==
                       target[i]
                 @test round(decrement(mort, t, methods[i]), digits = 4) ==
                       round(1 - target[i], digits = 4)
@@ -78,17 +78,17 @@
     @testset "Error when asking for a fractional without assumption" begin
         mort = UltimateMortality([0.20, 0.50])
         @test_throws MethodError decrement(mort, 0, 1, 1.5)
-        @test_throws MethodError survivorship(mort, 0, 1, 1.5)
+        @test_throws MethodError survival(mort, 0, 1, 1.5)
     end
 
     @testset "Issue #60 - starting with non-integer ages" begin
         m = UltimateMortality([0.5 for i in 1:8])
         
-        @test survivorship(m,1,2) ≈ 0.5
-        @test survivorship(m,1.5,2.5,Constant()) ≈ 0.5
-        @test survivorship(m,1.5,3.5,Constant()) ≈ 0.25
-        @test survivorship(m,1.5,1.5 + eps(),Constant()) ≈ 1.0
-        @test survivorship(m,1,1 + eps(),Constant()) ≈ 1.0
+        @test survival(m,1,2) ≈ 0.5
+        @test survival(m,1.5,2.5,Constant()) ≈ 0.5
+        @test survival(m,1.5,3.5,Constant()) ≈ 0.25
+        @test survival(m,1.5,1.5 + eps(),Constant()) ≈ 1.0
+        @test survival(m,1,1 + eps(),Constant()) ≈ 1.0
 
     end
 

--- a/test/parameterized_models.jl
+++ b/test/parameterized_models.jl
@@ -4,8 +4,8 @@
 
         g = Gompertz(a=0.0002,b=.13)
 
-        @test survivorship(g,45) ≈ 0.5870365016720939
-        @test survivorship(g,45,46) ≈ 0.9285202788707242
+        @test survival(g,45) ≈ 0.5870365016720939
+        @test survival(g,45,46) ≈ 0.9285202788707242
         @test decrement(g,45,46) ≈ 1 - 0.9285202788707242
         @test hazard(g,45) ≈ 0.06944687609574696
 
@@ -18,15 +18,15 @@
             
             # vs manually calculated (via QuadGK) integrals
             @test decrement(m, 20, 25) ≈ 0.0012891622754368504
-            @test survivorship(m, 20, 25) ≈ 1 - 0.0012891622754368504
+            @test survival(m, 20, 25) ≈ 1 - 0.0012891622754368504
             @test decrement(m, 25) ≈ 0.005888764668801838
-            @test survivorship(m, 25) ≈ 1 - 0.005888764668801838
+            @test survival(m, 25) ≈ 1 - 0.005888764668801838
 
             # these values come from the 'Standard Select and Ultimate Survival Model'
             # from Actuarial Mathematics for Life Contingent Risks, 2nd end
 
             ℓ = 100_000
-            ℓs = [survivorship(m, 20, age) for age in 21:100] .* ℓ
+            ℓs = [survival(m, 20, age) for age in 21:100] .* ℓ
 
             ℓ_age(x) = ℓs[x - 20]
             @test isapprox(ℓ_age(21),  99975.04, atol = 0.01)
@@ -44,8 +44,8 @@
         g = Gompertz(a=2.7e-6,b= 1.124)
 
         for age ∈ 20:100
-            @test survivorship(m, age) == survivorship(g, age)
-            @test survivorship(m, age, 1) == survivorship(g, age, 1)
+            @test survival(m, age) == survival(g, age)
+            @test survival(m, age, 1) == survival(g, age, 1)
         end
     end
 
@@ -119,18 +119,18 @@
             #test Survival
             if "Sx" in keys(rmodel)
                 for (i,age) in enumerate(ages)
-                    @test survivorship(model.juliamodel,age) ≈ rmodel["Sx"][i] 
+                    @test survival(model.juliamodel,age) ≈ rmodel["Sx"][i] 
                 end
             end
 
             # test other characteristics
 
-            @test survivorship(model.juliamodel,20,20) == 1.0
+            @test survival(model.juliamodel,20,20) == 1.0
             if model.rmodel in ["quadratic","perks","vandermaen","vandermaen2"]
                 # the default params create a crazy hazard function 
-                @test_broken survivorship(model.juliamodel,50,51) < 1.0
+                @test_broken survival(model.juliamodel,50,51) < 1.0
             else
-                @test survivorship(model.juliamodel,50,51) < 1.0
+                @test survival(model.juliamodel,50,51) < 1.0
             end
             
             @test model.juliamodel[20] >= 0


### PR DESCRIPTION
`survival` is shorter and a bit more definitionally correct:

- `survivorship`: The state of being a survivor. 
- `survival`: The fact or act of surviving; continued existence or life. 
