### PR TITLE
Fix parsing of CSVs change in v0.7.8 of CSV

### DIFF
--- a/src/CSV.jl
+++ b/src/CSV.jl
@@ -136,7 +136,7 @@ end
 
 function last_values_line(lines,startline)
 	for i in startline:lastindex(lines)
-		if ismissing(lines[i][1])
+		if ismissing(lines[i][1]) | startswith(lines[i][1], "Table")
 			return i - 1
 		end
 	end


### PR DESCRIPTION
Before CSVv0.7.8, empty lines were read with missing values and the last_values_line looked for the missing row. Now, look for end of the files or for "Table" to indicate end of subtable

closes #93