### PR TITLE
Update Parsers compat to include v2.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
 OffsetArrays = "1.0"
-Parsers = "^1"
+Parsers = "^1, 2"
 QuadGK = "^2.3"
 Requires = "^1"
 UnPack = "^1"


### PR DESCRIPTION
Nothing changed in the `Parsers.parse` contract, so this shouldn't cause any problems.