### PR TITLE
Provide default table object when not parsing into standard format

### DIFF
--- a/src/XTbML.jl
+++ b/src/XTbML.jl
@@ -155,7 +155,7 @@ function parseXTbMLTable(x, path)
         end
     else
         # return generic table
-        return XTbML_Generic(tables,d)
+        return XTbML_Generic([t.dict for t in tables],d)
     end
 
 end
@@ -197,6 +197,10 @@ function XTbML_Table_To_MortalityTable(tbl::XTbML_Ultimate)
             )
 
     return MortalityTable(ult, metadata=tbl.d)
+end
+
+function XTbML_Table_To_MortalityTable(tbl::XTbML_Generic)
+    return tbl
 end
 
 """

--- a/src/XTbML.jl
+++ b/src/XTbML.jl
@@ -76,9 +76,14 @@ end
 parse a 1D table
 """
 function parse_1D_table(tbl)
-    map(tbl["Values"]["Axis"]["Y"]) do ai 
-        (age  = Parsers.parse(Int, ai[:t]), rate = get_and_parse(ai, ""),)
+    vals_xml = tbl["Values"]["Axis"]["Y"]
+    first_index = Parsers.parse(Int,first(vals_xml)[:t])
+    
+    vals = map(vals_xml) do ai 
+        get_and_parse(ai, "")
     end
+
+    return OffsetArray(vals,first_index-1)
 end
 
 # get potentially missing value out of dict
@@ -161,10 +166,7 @@ function parseXTbMLTable(x, path)
 end
 
 function XTbML_Table_To_MortalityTable(tbl::XTbML_SelectUltimate)
-    ult = UltimateMortality(
-                [v.rate for v in  tbl.ultimate], 
-                start_age=tbl.ultimate[1].age
-            )
+    ult = tbl.ultimate
 
     ult_omega = lastindex(ult)
 
@@ -191,12 +193,7 @@ function XTbML_Table_To_MortalityTable(tbl::XTbML_SelectUltimate)
 end
 
 function XTbML_Table_To_MortalityTable(tbl::XTbML_Ultimate)
-    ult = UltimateMortality(
-                [v.rate for v in  tbl.ultimate], 
-                start_age=tbl.ultimate[1].age
-            )
-
-    return MortalityTable(ult, metadata=tbl.d)
+    return MortalityTable(tbl.ultimate, metadata=tbl.d)
 end
 
 function XTbML_Table_To_MortalityTable(tbl::XTbML_Generic)

--- a/src/XTbML.jl
+++ b/src/XTbML.jl
@@ -81,8 +81,12 @@ parse a 1D table
 """
 function parse_1D_table(tbl,index_adj=0)
     first_index = Parsers.parse(Int,first(tbl)[:t])
-    
-    vals = [get_and_parse(ai,"") for ai in tbl]
+    last_index = Parsers.parse(Int,last(tbl)[:t])
+
+    # some tables (e.g. 2975) don't have contiguous indices, so create interim dict to make 
+    # dynamically creating an array with potentially missing values easy
+    d = Dict(Parsers.parse(Int,x[:t]) => get_and_parse(x,"") for x in tbl)
+    vals = [get(d,i,missing) for i in first_index:last_index]
 
     while ismissing(last(vals))
         # drop trailing missings, but not leading (e.g. keep leading for table 1076)

--- a/src/XTbML.jl
+++ b/src/XTbML.jl
@@ -109,18 +109,39 @@ end
 struct XTbML_SelectUltimate
     select
     ultimate
-    d::TableMetaData
+    metadata::TableMetaData
 end
 
 struct XTbML_Ultimate
     ultimate
-    d::TableMetaData
+    metadata::TableMetaData
 end
 
 struct XTbML_Generic
     tables
-    d::TableMetaData
+    metadata::TableMetaData
 end
+
+Base.show(io::IO, ::MIME"text/plain", mt::XTbML_Generic) = print(
+    io,
+    """
+    MortalityTable ($(mt.metadata.content_type)):
+       Name:
+           $(mt.metadata.name)
+       Fields: 
+           $(fieldnames(typeof(mt)))
+       Provider:
+           $(mt.metadata.provider)
+       mort.SOA.org ID:
+           $(mt.metadata.id)
+       mort.SOA.org link:
+           https://mort.soa.org/ViewTable.aspx?&TableIdentity=$(mt.metadata.id)
+       Description:
+           $(mt.metadata.description)
+        Note:
+            The requested table is not a known type. The values provided will be in a generic format for accessibility, but will not follow the same API as structured tables. See [#TODO link to doc site describing possible breaking changes further].
+    """,
+)
 
 function parseXTbMLTable(x, path)
     md = x["XTbML"]["ContentClassification"]

--- a/src/XTbML.jl
+++ b/src/XTbML.jl
@@ -200,6 +200,7 @@ function XTbML_Table_To_MortalityTable(tbl::XTbML_Ultimate)
 end
 
 function XTbML_Table_To_MortalityTable(tbl::XTbML_Generic)
+    @warn "The requested table is not a known type. The values provided will be in a generic format for accessibility, but will not follow the same API as structured tables. See [#TODO link to doc site describing possible breaking changes further]."
     return tbl
 end
 

--- a/src/XTbML.jl
+++ b/src/XTbML.jl
@@ -162,7 +162,7 @@ function parseXTbMLTable(x, path)
             return XTbML_SelectUltimate(sel,ult,d)
         else
             # return generic table
-            return XTbML_Generic(tables,d)
+            return XTbML_Generic([t.dict for t in tables],d)
         end
     else
         # return generic table

--- a/src/XTbML.jl
+++ b/src/XTbML.jl
@@ -58,9 +58,14 @@ function get_and_parse(dict, key)
     end        
 end
 
-struct XTbMLTable{S,U}
-    select::S
-    ultimate::U
+struct XTbML_SelectUltimate
+    select
+    ultimate
+    d::TableMetaData
+end
+
+struct XTbML_Ultimate
+    ultimate
     d::TableMetaData
 end
 
@@ -92,25 +97,20 @@ function parseXTbMLTable(x, path)
 
         ult = parse_1D_table(x["XTbML"]["Table"][2])
 
+        return XTbML_SelectUltimate(sel,ult,d)
+
     else
         # a table without select period will just have one set of values
 
         ult = parse_1D_table(x["XTbML"]["Table"])
 
-        sel = nothing
+        return XTbML_Ultimate(ult,d)
 
     end
 
-    tbl = XTbMLTable(
-        sel,
-        ult,
-        d
-    )
-
-    return tbl
 end
 
-function XTbML_Table_To_MortalityTable(tbl::XTbMLTable)
+function XTbML_Table_To_MortalityTable(tbl::XTbML_SelectUltimate)
     ult = UltimateMortality(
                 [v.rate for v in  tbl.ultimate], 
                 start_age=tbl.ultimate[1].age
@@ -118,30 +118,35 @@ function XTbML_Table_To_MortalityTable(tbl::XTbMLTable)
 
     ult_omega = lastindex(ult)
 
-    if !isnothing(tbl.select)
-        sel =   map(tbl.select) do (issue_age, rates)
-            last_sel_age = issue_age + rates[end].duration - 1
-            first_defined_select_age =  issue_age + rates[1].duration - 1
-            last_age = max(last_sel_age, ult_omega)
-            vec = map(issue_age:last_age) do attained_age
-                if attained_age < first_defined_select_age
-                    return missing
+    sel =   map(tbl.select) do (issue_age, rates)
+        last_sel_age = issue_age + rates[end].duration - 1
+        first_defined_select_age =  issue_age + rates[1].duration - 1
+        last_age = max(last_sel_age, ult_omega)
+        vec = map(issue_age:last_age) do attained_age
+            if attained_age < first_defined_select_age
+                return missing
+            else
+                if attained_age <= last_sel_age
+                    return rates[attained_age - first_defined_select_age + 1].rate
                 else
-                    if attained_age <= last_sel_age
-                        return rates[attained_age - first_defined_select_age + 1].rate
-                    else
-                        return ult[attained_age]
-                    end
+                    return ult[attained_age]
                 end
-            end 
-            return mortality_vector(vec, start_age=issue_age)
-        end
-        sel = OffsetArray(sel, tbl.select[1].issue_age - 1)
-
-        return MortalityTable(sel, ult, metadata=tbl.d)
-    else
-        return MortalityTable(ult, metadata=tbl.d)
+            end
+        end 
+        return mortality_vector(vec, start_age=issue_age)
     end
+    sel = OffsetArray(sel, tbl.select[1].issue_age - 1)
+
+    return MortalityTable(sel, ult, metadata=tbl.d)
+end
+
+function XTbML_Table_To_MortalityTable(tbl::XTbML_Ultimate)
+    ult = UltimateMortality(
+                [v.rate for v in  tbl.ultimate], 
+                start_age=tbl.ultimate[1].age
+            )
+
+    return MortalityTable(ult, metadata=tbl.d)
 end
 
 """

--- a/test/XTbML.jl
+++ b/test/XTbML.jl
@@ -14,7 +14,7 @@
         pth = joinpath(soa_tbl_dir,"t1076.xml")
         file = MortalityTables.open_and_read(pth) |> MortalityTables.getXML
         xtbl = MortalityTables.parseXTbMLTable(file, pth)
-        @test isa(xtbl, MortalityTables.XTbMLTable)
+        @test isa(xtbl, MortalityTables.XTbML_SelectUltimate)
     end
 
     @testset "Ultimate Only" begin


### PR DESCRIPTION
Closes #107

- [x] return generic datatype for non-standard tables
- [x] decouple parsing logic to not assume everthing is a select or ultimate mortality table

improve generic data returned by:

- [x] add usage warning via `@info`
- [x] refactor interim steps to make fewer assumptions about the contents of the table (e.g. `parse_2D_table` assumes indices are issue_age and duration)
- [ ] iterate on generic table API to get to a happy spot
- [x] parse table metadata for display methods and/or value index information
- [x] how to handle non-contiguous indices? idea: just be `missing` for missing values
other todo:

- [ ] docuemnt in API which parts are stable, experimental
- [ ] add test cases