### PR TITLE
reduce allocations by not broadcasting (+ formatting/spelling)

### DIFF
--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1,28 +1,28 @@
 
 @testset "basic MortalityTable" begin
     @testset "basic structure" begin
-        q1 = UltimateMortality([i for i = 0:19], start_age=0)
+        q1 = UltimateMortality([i for i = 0:19], start_age = 0)
         @test q1[0] == 0
         @test q1[1] == 1
         @test q1[0:1] == [0, 1]
         @test omega(q1) == 19
-        @test_throws BoundsError q1[omega(q1) + 1]
+        @test_throws BoundsError q1[omega(q1)+1]
 
         # non-zero start age
-        q2 = UltimateMortality([i for i = 0:9], start_age=5)
+        q2 = UltimateMortality([i for i = 0:9], start_age = 5)
         @test_throws BoundsError q2[4]
         @test q2[5] == 0
 
         # select strucutre
         s = [ia + d for ia = 0:5, d = 0:4]
 
-        q3 = SelectMortality(s, q1, start_age=0)
+        q3 = SelectMortality(s, q1, start_age = 0)
         @test q3[0][0] == 0
         @test q3[0][0:1] == [0, 1]
         @test omega(q3[0]) == 19
-        @test_throws BoundsError q3[omega(q3[0]) + 1]
+        @test_throws BoundsError q3[omega(q3[0])+1]
         @test q3[0][19] == 19
-        
+
         @test q3[5][5] == 5
 
 
@@ -39,22 +39,22 @@
     end
 
     @testset "off-aligned select and ult" begin
-        select_matrix = [(i + j - 1) / 100 for i in 0:10,j in 1:20]
-        ult = UltimateMortality([i / 100 for i in 18:100], start_age=18)
+        select_matrix = [(i + j - 1) / 100 for i = 0:10, j = 1:20]
+        ult = UltimateMortality([i / 100 for i = 18:100], start_age = 18)
 
         select = SelectMortality(select_matrix, ult)
 
-        for issue_age in 0:10
-            for dur in 1:30
-                @test select[issue_age][issue_age + dur - 1] == (issue_age + dur - 1) / 100
+        for issue_age = 0:10
+            for dur = 1:30
+                @test select[issue_age][issue_age+dur-1] == (issue_age + dur - 1) / 100
             end
         end
     end
 
     # test time zero accumlated force
     @testset "accumulated force" begin
-        q4 = UltimateMortality([0.1,0.3,0.6,1])
-        
+        q4 = UltimateMortality([0.1, 0.3, 0.6, 1])
+
         @test survival(q4, 0) ≈ 1
         @test decrement(q4, 0) ≈ 0
 
@@ -65,11 +65,11 @@
         @test survival(q4, 1, 2) ≈ 0.7
         @test decrement(q4, 1, 1) ≈ 0.0
         @test decrement(q4, 1, 2) ≈ 0.3
-        
+
         @test survival(q4, 1, 4) ≈ 0.0
         @test decrement(q4, 1, 4) ≈ 1.0
 
-        
+
         @test survival(q4, -1) ≈ 1.0
         @test survival(q4, 4, -1) ≈ 1.0
         @test decrement(q4, -1) ≈ 0.0
@@ -80,20 +80,24 @@
         d = TableMetaData()
 
         @test isnothing(d.name)
-        
-        d = TableMetaData(name="test")
+
+        d = TableMetaData(name = "test")
         @test d.name == "test"
     end
 
     @testset "mortality_vector" begin
-        v = [i for i in 3:10]
-        q = mortality_vector(v, start_age=3)
+        v = [i for i = 3:10]
+        q = mortality_vector(v, start_age = 3)
         @test q[3] == 3
         @test q[10] == 10
 
         q = mortality_vector(collect(0:5))
         @test q[0] == 0
         @test q[5] == 5
+    end
+
+    @testset "utility functions" begin
+        @test MortalityTables._decrement(1.0, 0.05) ≈ 1.0 * (1 - 0.05)
     end
 
 end


### PR DESCRIPTION
# Before 
```
julia> @benchmark survival($t.ultimate,50,80)
BenchmarkTools.Trial: 10000 samples with 991 evaluations.
 Range (min … max):  40.448 ns … 420.240 ns  ┊ GC (min … max): 0.00% … 85.84%
 Time  (median):     43.769 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   46.705 ns ±  26.898 ns  ┊ GC (mean ± σ):  4.40% ±  6.76%

       ▃██▆▃                                                    
  ▂▂▂▂▆██████▅▅▅▄▃▃▃▃▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  40.4 ns         Histogram: frequency by time           65 ns <

 Memory estimate: 304 bytes, allocs estimate: 1.
```
# After
```
 julia> @benchmark survival($t.ultimate,50,80)
BenchmarkTools.Trial: 10000 samples with 997 evaluations.
 Range (min … max):  21.648 ns … 38.824 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     21.858 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   22.063 ns ±  0.745 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▃███▅▂▁      ▁▂▂▃▁▁         ▂▁▂  ▁                         ▂
  ▇███████▆▇▅▅▆▄██████▇██▇█▆▇▇▆██████▇▇▃▆▅▅▅▃▄▃▄▁▃▅▃▃▄▁▁▄▄▃▄▅ █
  21.6 ns      Histogram: log(frequency) by time      25.1 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
 ```