### PR TITLE
switch from XMLDict.jl to XML.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StringDistances = "88034a9c-02f8-509d-84a9-84ec65e18404"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+XML = "72c71f33-b9b6-44de-8c94-c961784809e2"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]

--- a/src/MortalityTables.jl
+++ b/src/MortalityTables.jl
@@ -7,6 +7,7 @@ using Requires
 import StringDistances
 using UnPack
 using XMLDict
+import XML
 using Pkg.Artifacts
 
 include("table_source_map.jl")
@@ -35,6 +36,7 @@ export MortalityTable,
     Constant,
     DeathDistribution,
     get_SOA_table,
+    get_SOA_table2,
     Makeham, Gompertz, MakehamGompertz,
     hazard,cumhazard,
     mortality_vector

--- a/src/get_SOA_table.jl
+++ b/src/get_SOA_table.jl
@@ -10,6 +10,29 @@ function get_SOA_table(id::Int)
     readXTbML(joinpath(artifact"mort.soa.org", "t$id.xml"))
 end
 
+function get_SOA_table2(id::Int)
+    path = joinpath(artifact"mort.soa.org", "t$id.xml")
+    leading_bytes = read(path,3)
+    skipbytes = leading_bytes == [0xef, 0xbb, 0xbf]
+            # Why skip the first three bytes of the response?
+
+        # From https://docs.python.org/3/library/codecs.html
+        # To increase the reliability with which a UTF-8 encoding can be detected,
+        # Microsoft invented a variant of UTF-8 (that Python 2.5 calls "utf-8-sig")
+        # for its Notepad program: Before any of the Unicode characters is written
+        # to the file, a UTF-8 encoded BOM (which looks like this as a byte sequence:
+        # 0xef, 0xbb, 0xbf) is written.
+
+    x = open(path,"r") do f
+        skipbytes && skip(f,3)
+        XML.XMLTokenIterator(f) |> XML.Document
+    end
+
+    # t = parseXTbMLTable2(x,path)
+    # XTbML_Table_To_MortalityTable(t)
+
+end
+
 function get_SOA_table(table_name::String; source_map = table_source_map)
     entry = get(source_map, table_name, nothing)
     if entry === nothing


### PR DESCRIPTION
Try using a juila-native package for performance.

Unfortunately, it seems like reading the tables is dominated by the slower performance of `XML.Document` versus `XMLDict.xml_dict`

Using XML:

```julia-repl
julia> @btime MortalityTables.get_SOA_table2(1117)
  9.379 ms (175581 allocations: 8.43 MiB)
```

Using XML:

```julia-repl
ulia> @btime MortalityTables.get_SOA_table(1117)
  6.108 μs (62 allocations: 6.70 KiB)
```


- [ ] needs to parse metadata in `parseXTbMLTable2`